### PR TITLE
Examples for Form Actions built-in to Symfony

### DIFF
--- a/Form/Type/ExampleHorizontalFormType.php
+++ b/Form/Type/ExampleHorizontalFormType.php
@@ -53,6 +53,12 @@ class ExampleHorizontalFormType extends AbstractType
                     'rows'  => 3
                 )
             ))
+            ->add('buttons', 'form_actions', array(
+                    'buttons' => array(
+                        'save' => array('type' => 'submit', 'options' => array('label' => 'Save changes')),
+                        'cancel' => array('type' => 'button'),
+                    )
+                ))
         ;
     }
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/Resources/views/Examples/horizontal.html.twig
+++ b/Resources/views/Examples/horizontal.html.twig
@@ -6,12 +6,6 @@
 {% block content_row %}
 <form class="bs-example form-horizontal">
     {{ form_widget(form) }}
-    <div class="form-group">
-        <div class="col-offset-3 col-lg-9">
-            <button type="submit" class="btn btn-primary">Save changes</button>
-            <button type="reset" class="btn">Cancel</button>
-        </div>
-    </div>
 </form>
 <div class="col-lg-6">
     <h3>What's included</h3>


### PR DESCRIPTION
Added example to the horizontal form page, where this is mostly used.
